### PR TITLE
add cookie support

### DIFF
--- a/src/util/authentication.ts
+++ b/src/util/authentication.ts
@@ -3,6 +3,7 @@
  */
 
 export let BEARER = "";
+export let COOKIE = "";
 
 /**
  * Sets the Bearer Token to provide to robotevents. This is useful if you have
@@ -15,10 +16,22 @@ export function setBearer(bearer: string) {
 }
 
 /**
+ * Sets the Cookie to provide to robotevents.
+ * because access API by bearer will not get the limit info in Response.header.
+ * but When access API by cookie, they will give the limit info back.
+ * So We can set the cookie instead of the official Bearer.
+ *
+ * @param cookie
+ */
+export function setCookie(cookie: string) {
+  return (COOKIE = cookie);
+}
+
+/**
  * Checks if the user agent has been authenticated correctly. If this function
  * returns true you may not be ok to make requests, as your session cookie may
  * have been revoked early, however it is generally a good indicator
  */
 export function ok() {
-  return BEARER !== "";
+  return BEARER !== "" || COOKIE != "";
 }

--- a/src/util/request.ts
+++ b/src/util/request.ts
@@ -9,7 +9,7 @@
 
 import fetch from "cross-fetch";
 import { ready, updateCurrent } from "./ratelimit";
-import { BEARER } from "./authentication";
+import { BEARER, COOKIE } from "./authentication";
 
 /**
  * Serializes parameters into a string to be passed to the API
@@ -70,6 +70,9 @@ async function doRequest<T = unknown>(url: URL): Promise<T> {
   if (BEARER) {
     headers["Authorization"] = `Bearer ${BEARER}`;
   }
+  if (COOKIE) {
+    headers["Cookie"] = COOKIE;
+  }
 
   // Make the initial request
   const response = await fetch(url.href, {
@@ -85,7 +88,10 @@ async function doRequest<T = unknown>(url: URL): Promise<T> {
 
   // If the response errored reject accordingly
   if (!response.ok) {
-    return Promise.reject(await response.text());
+    const status = response.status;
+    const statusText = response.statusText;
+    const text = await response.text();
+    return Promise.reject({ status, statusText, text });
   }
 
   return response.json();


### PR DESCRIPTION
Access the API with Bearer will not get the "X-Ratelimit-Remaining". So the ratelimit don't work.

but when you get API with cookie they will give the limit info back. So I add setCookie to authentication.