### PR TITLE
Remove `directories` from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,6 @@
   "dependencies": {
     "openapi-fetch": "^0.11.1"
   },
-  "directories": {
-    "bin": "./out",
-    "lib": "./src"
-  },
   "devDependencies": {
     "@types/cookie": "^0.4.0",
     "@types/set-cookie-parser": "^0.0.6",


### PR DESCRIPTION
Removed `directories` section from `package.json`

Specifically, `directories.bin` is causing issues with `yarn@4` as it expands (https://docs.npmjs.com/cli/v11/configuring-npm/package-json#directoriesbin) all of the files and directories (incorrectly) inside the referenced directory as`bin`, for instance:

```
  bin:
    Event.d.ts: out/wrappers/Event.d.ts
    Event.js: out/wrappers/Event.js
    Event.js.map: out/wrappers/Event.js.map
    Match.d.ts: out/wrappers/Match.d.ts
    Match.js: out/wrappers/Match.js
    Match.js.map: out/wrappers/Match.js.map
    Team.d.ts: out/wrappers/Team.d.ts
    Team.js: out/wrappers/Team.js
    Team.js.map: out/wrappers/Team.js.map
    client.d.ts: out/utils/client.d.ts
    client.js: out/utils/client.js
    client.js.map: out/utils/client.js.map
    endpoints: out/endpoints
    events.d.ts: out/endpoints/events.d.ts
    events.js: out/endpoints/events.js
    events.js.map: out/endpoints/events.js.map
    generated: out/generated
    main.d.ts: out/main.d.ts
    main.js: out/main.js
    main.js.map: out/main.js.map
    programs.d.ts: out/endpoints/programs.d.ts
    programs.js: out/endpoints/programs.js
    programs.js.map: out/endpoints/programs.js.map
    robotevents.d.ts: out/generated/robotevents.d.ts
    robotevents.js: out/generated/robotevents.js
    robotevents.js.map: out/generated/robotevents.js.map
    seasons.d.ts: out/endpoints/seasons.d.ts
    seasons.js: out/endpoints/seasons.js
    seasons.js.map: out/endpoints/seasons.js.map
    shim.d.ts: out/generated/shim.d.ts
    shim.js: out/generated/shim.js
    shim.js.map: out/generated/shim.js.map
    teams.d.ts: out/endpoints/teams.d.ts
    teams.js: out/endpoints/teams.js
    teams.js.map: out/endpoints/teams.js.map
    types.d.ts: out/types.d.ts
    types.js: out/types.js
    types.js.map: out/types.js.map
    utils: out/utils
    wrappers: out/wrappers
```

Given that entries as `out/generated`, `out/utils` and `out/wrappers` are directories, yarn fails as it expects them to be files.

As this is not a CLI tool, don't think this library really needs this `directory.bin` declaration anyways.

Will be raising a bug in `yarn` as well

Thanks